### PR TITLE
feat: suporte a produtos grade e variações (/v1/variacoes)

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -11,10 +11,11 @@ use Fuganholi\MercosIntegration\Traits\OrderEntity;
 use Fuganholi\MercosIntegration\Traits\ProductEntity;
 use Fuganholi\MercosIntegration\Traits\StockEntity;
 use Fuganholi\MercosIntegration\Traits\UserEntity;
+use Fuganholi\MercosIntegration\Traits\VariationEntity;
 
 class Api extends Client
 {
-    use CategoryEntity, UserEntity, CarrierEntity, CustomerEntity, ProductEntity, StockEntity, OrderEntity;
+    use CategoryEntity, UserEntity, CarrierEntity, CustomerEntity, ProductEntity, StockEntity, OrderEntity, VariationEntity;
 
     private static $API_URL = [
         ApiConfig::PRODUCTION_ENVIRONMENT => 'https://app.mercos.com/api',

--- a/src/Dto/Product/Produto.php
+++ b/src/Dto/Product/Produto.php
@@ -21,6 +21,9 @@ class Produto extends Validable
         'observacoes' => 'nullable|max:5000'
     ];
 
+    /** @var ProdutoGrade[] */
+    protected array $produtos_grade = [];
+
     public function __construct(
         public ?int $id = null,
         public ?string $codigo = null,
@@ -50,5 +53,43 @@ class Produto extends Validable
         public ?\DateTime $ultima_alteracao = null
     ) {
         //
+    }
+
+    public static function create(\stdClass $p): static
+    {
+        $produto = parent::create($p);
+
+        foreach (($p?->produtos_grade ?? []) as $grade) {
+            $produto->addProdutoGrade(ProdutoGrade::create($grade));
+        }
+
+        return $produto;
+    }
+
+    public function addProdutoGrade(ProdutoGrade $grade): void
+    {
+        $this->produtos_grade[] = $grade;
+    }
+
+    /**
+     * @return ProdutoGrade[]
+     */
+    public function getProdutosGrade(): array
+    {
+        return $this->produtos_grade;
+    }
+
+    public function hasGrade(): bool
+    {
+        return !empty($this->produtos_grade);
+    }
+
+    public function toArray(): array
+    {
+        $serialized = parent::toArray();
+
+        if (empty($serialized['produtos_grade'])) unset($serialized['produtos_grade']);
+
+        return $serialized;
     }
 }

--- a/src/Dto/Product/ProdutoGrade.php
+++ b/src/Dto/Product/ProdutoGrade.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Fuganholi\MercosIntegration\Dto\Product;
+
+use Fuganholi\MercosIntegration\Dto\Serializable;
+
+class ProdutoGrade extends Serializable
+{
+    /** @var int[] */
+    protected array $itens_variacoes_ids = [];
+    /** @var array<string, string>[] */
+    protected array $itens_variacoes_nomes = [];
+
+    public function __construct(
+        public ?int $id = null,
+        public ?string $codigo = null,
+        public ?bool $ativo = null,
+        public ?bool $excluido = null,
+        public ?bool $exibir_no_b2b = null,
+        public ?float $preco_tabela = null,
+    ) {
+        //
+    }
+
+    public static function create(\stdClass $g): static
+    {
+        $grade = parent::create($g);
+
+        foreach (($g?->itens_variacoes_ids ?? []) as $itemId) {
+            $grade->addItemVariacaoId($itemId);
+        }
+
+        foreach (($g?->itens_variacoes_nomes ?? []) as $itemNome) {
+            $grade->addItemVariacaoNome((array) $itemNome);
+        }
+
+        return $grade;
+    }
+
+    public function toArray(): array
+    {
+        $serialized = parent::toArray();
+
+        foreach (['itens_variacoes_ids', 'itens_variacoes_nomes'] as $list) {
+            if (empty($serialized[$list])) unset($serialized[$list]);
+        }
+
+        return $serialized;
+    }
+
+    public function addItemVariacaoId(int $itemVariacaoId): void
+    {
+        $this->itens_variacoes_ids[] = $itemVariacaoId;
+    }
+
+    /**
+     * @param array<string, string> $itemVariacaoNome
+     */
+    public function addItemVariacaoNome(array $itemVariacaoNome): void
+    {
+        $this->itens_variacoes_nomes[] = $itemVariacaoNome;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getItensVariacoesIds(): array
+    {
+        return $this->itens_variacoes_ids;
+    }
+
+    /**
+     * @return array<string, string>[]
+     */
+    public function getItensVariacoesNomes(): array
+    {
+        return $this->itens_variacoes_nomes;
+    }
+}

--- a/src/Dto/Variation/ItemVariacao.php
+++ b/src/Dto/Variation/ItemVariacao.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Fuganholi\MercosIntegration\Dto\Variation;
+
+use Fuganholi\MercosIntegration\Dto\Serializable;
+
+class ItemVariacao extends Serializable
+{
+    public function __construct(
+        public ?int $id = null,
+        public ?string $nome = null,
+        public ?int $ordem = null,
+        public ?string $cor = null,
+        public ?bool $excluido = null,
+        public ?string $imagem_url = null,
+        public ?string $imagem_base64 = null,
+    ) {
+        //
+    }
+}

--- a/src/Dto/Variation/Variacao.php
+++ b/src/Dto/Variation/Variacao.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Fuganholi\MercosIntegration\Dto\Variation;
+
+use Fuganholi\MercosIntegration\Dto\Validable;
+
+class Variacao extends Validable
+{
+    protected static array $casts = [
+        'ultima_alteracao' => 'date:Y-m-d H:i:s'
+    ];
+
+    protected array $fieldsRules = [
+        'nome'  => 'required|max:20',
+        'ordem' => 'required',
+    ];
+
+    /** @var ItemVariacao[] */
+    protected array $itens_variacao = [];
+
+    public function __construct(
+        public ?int $id = null,
+        public ?string $nome = null,
+        public ?int $ordem = null,
+        public ?bool $excluido = null,
+        public ?\DateTime $ultima_alteracao = null,
+    ) {
+        //
+    }
+
+    public static function create(\stdClass $v): static
+    {
+        $variacao = parent::create($v);
+
+        foreach (($v?->itens_variacao ?? []) as $item) {
+            $variacao->addItemVariacao(ItemVariacao::create($item));
+        }
+
+        return $variacao;
+    }
+
+    public function addItemVariacao(ItemVariacao $item): void
+    {
+        $this->itens_variacao[] = $item;
+    }
+
+    /**
+     * @return ItemVariacao[]
+     */
+    public function getItensVariacao(): array
+    {
+        return $this->itens_variacao;
+    }
+
+    public function toArray(): array
+    {
+        $serialized = parent::toArray();
+
+        if (empty($serialized['itens_variacao'])) unset($serialized['itens_variacao']);
+
+        return $serialized;
+    }
+}

--- a/src/Exceptions/CreateVariationException.php
+++ b/src/Exceptions/CreateVariationException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Fuganholi\MercosIntegration\Exceptions;
+
+use Exception;
+
+class CreateVariationException extends Exception
+{
+    //
+}

--- a/src/Exceptions/GetVariationsException.php
+++ b/src/Exceptions/GetVariationsException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Fuganholi\MercosIntegration\Exceptions;
+
+use Exception;
+
+class GetVariationsException extends Exception
+{
+    //
+}

--- a/src/Exceptions/UpdateVariationException.php
+++ b/src/Exceptions/UpdateVariationException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Fuganholi\MercosIntegration\Exceptions;
+
+use Exception;
+
+class UpdateVariationException extends Exception
+{
+    //
+}

--- a/src/Traits/ProductEntity.php
+++ b/src/Traits/ProductEntity.php
@@ -56,6 +56,28 @@ trait ProductEntity
         return $response->getHeaders('meuspedidosid');
     }
 
+    /**
+     * Cria um produto e devolve o corpo da resposta (id do agregador + ids/códigos
+     * dos produtos grade na mesma ordem enviada). Use para produtos grade.
+     */
+    public function createProductWithGrade(Produto $data): Produto|null
+    {
+        $data->validate();
+
+        $response = $this->post(self::PRODUCT_ENTITY, $data->toArray());
+
+        if (!$response->isSuccess()) {
+            Thrower::withHttpResponse($response)
+                ->throwException(CreateProductException::class, 'An error occured when trying to create the product!');
+        }
+
+        $body = $response->getResponseJson();
+
+        if (!is_object($body)) return null;
+
+        return Produto::create($body);
+    }
+
     public function updateProduct(int $productId, Produto $data): void
     {
         $data->validate();
@@ -66,5 +88,27 @@ trait ProductEntity
             Thrower::withHttpResponse($response)
                 ->throwException(UpdateProductException::class, 'An error occured when trying to update the product!');
         }
+    }
+
+    /**
+     * Atualiza um produto e devolve o corpo da resposta (id do agregador + ids/códigos
+     * dos produtos grade na mesma ordem enviada). Use para produtos grade.
+     */
+    public function updateProductWithGrade(int $productId, Produto $data): Produto|null
+    {
+        $data->validate();
+
+        $response = $this->put(self::PRODUCT_ENTITY . "/$productId", $data->toArray());
+
+        if (!$response->isSuccess()) {
+            Thrower::withHttpResponse($response)
+                ->throwException(UpdateProductException::class, 'An error occured when trying to update the product!');
+        }
+
+        $body = $response->getResponseJson();
+
+        if (!is_object($body)) return null;
+
+        return Produto::create($body);
     }
 }

--- a/src/Traits/VariationEntity.php
+++ b/src/Traits/VariationEntity.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Fuganholi\MercosIntegration\Traits;
+
+use Fuganholi\MercosIntegration\Dto\GetParams;
+use Fuganholi\MercosIntegration\Dto\Variation\Variacao;
+use Fuganholi\MercosIntegration\Exceptions\CreateVariationException;
+use Fuganholi\MercosIntegration\Exceptions\GetVariationsException;
+use Fuganholi\MercosIntegration\Exceptions\UpdateVariationException;
+use Fuganholi\MercosIntegration\Helpers\Thrower;
+
+trait VariationEntity
+{
+    use HttpClientMethods;
+
+    const VARIATION_ENTITY = '/v1/variacoes';
+
+    /**
+     * @return Variacao[]
+     */
+    public function getVariations(GetParams $params = new GetParams())
+    {
+        $response = $this->get(self::VARIATION_ENTITY, $params->all());
+
+        if (!$response->isSuccess()) {
+            Thrower::withHttpResponse($response)
+                ->throwException(GetVariationsException::class, 'An error occured when trying to get all variations!');
+        }
+
+        return Variacao::createAllFromResponse($response);
+    }
+
+    public function getVariation(int $variationId): Variacao
+    {
+        $response = $this->get(self::VARIATION_ENTITY . "/$variationId");
+
+        if (!$response->isSuccess()) {
+            Thrower::withHttpResponse($response)
+                ->throwException(GetVariationsException::class, 'An error occured when trying to get the variation!');
+        }
+
+        return Variacao::createFromResponse($response);
+    }
+
+    /**
+     * Cria uma variação e devolve o corpo da resposta (id da variação +
+     * itens_variacoes na mesma ordem enviada).
+     */
+    public function createVariation(Variacao $data): mixed
+    {
+        $data->validate();
+
+        $response = $this->post(self::VARIATION_ENTITY, $data->toArray());
+
+        if (!$response->isSuccess()) {
+            Thrower::withHttpResponse($response)
+                ->throwException(CreateVariationException::class, 'An error occured when trying to create the variation!');
+        }
+
+        return $response->getResponseJson();
+    }
+
+    /**
+     * Atualiza uma variação e devolve o corpo da resposta (id da variação +
+     * itens_variacoes na mesma ordem enviada).
+     */
+    public function updateVariation(int $variationId, Variacao $data): mixed
+    {
+        $response = $this->put(self::VARIATION_ENTITY . "/$variationId", $data->toArray());
+
+        if (!$response->isSuccess()) {
+            Thrower::withHttpResponse($response)
+                ->throwException(UpdateVariationException::class, 'An error occured when trying to update the variation!');
+        }
+
+        return $response->getResponseJson();
+    }
+}


### PR DESCRIPTION
Adiciona suporte nativo a grade/variação na API Mercos:

- DTO ProdutoGrade e campo produtos_grade no DTO Produto, com serialização aninhada e XOR entre itens_variacoes_ids e itens_variacoes_nomes.
- DTOs Variacao e ItemVariacao para a entidade /v1/variacoes.
- Trait VariationEntity (get/getOne/create/update) registrado na Api.
- createProductWithGrade/updateProductWithGrade retornam o corpo da resposta para mapear os ids dos produtos grade pela ordem enviada; métodos createProduct/updateProduct legados permanecem inalterados.
- Exceptions Get/Create/UpdateVariationException.